### PR TITLE
Missing space in example

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,7 +111,7 @@ ${draw}
                 <span />
               </span>
               <pre className="prism-code">
-                <span className="token comment">// 1. Set up de package</span>
+                <span className="token comment">// 1. Set up the package</span>
                 <br />
                 <span className="token keyword">import</span> ContentLoader{' '}
                 <span className="token keyword">from </span>

--- a/src/App.js
+++ b/src/App.js
@@ -114,7 +114,7 @@ ${draw}
                 <span className="token comment">// 1. Set up de package</span>
                 <br />
                 <span className="token keyword">import</span> ContentLoader{' '}
-                <span className="token keyword">from</span>
+                <span className="token keyword">from </span>
                 <span className="token string">"react-content-loader"</span>
                 <br />
                 <br />


### PR DESCRIPTION
Hello!

In the example shown in the App there was a missing space in the import statement.
Bonus: there was a typo: `de`. -> `the`

Before:
![imagen](https://user-images.githubusercontent.com/993291/34005202-e92486dc-e0d8-11e7-881b-f7f426ee1011.png)

After:
![imagen](https://user-images.githubusercontent.com/993291/34005274-2e3ce7fa-e0d9-11e7-8287-b5f0e99cae87.png)

Cheers!