### PR TITLE
debounce color edits

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,11 +68,12 @@ class App extends Component {
   }
 
   _HandleInput = e => {
-    const name = e.target.name
-    const value = e.target.value
-
-    this.setState({ [name]: value, renderCanvas: false })
+    this._DebouncedStateUpdate(e.target.name, e.target.value)
   }
+
+  _DebouncedStateUpdate = debounce(250, (name, value) => {
+    this.setState({ [name]: value, renderCanvas: false })
+  })
 
   render() {
     const { width, height, speed, primaryColor, secondaryColor, draw, renderCanvas } = this.state

--- a/src/App.js
+++ b/src/App.js
@@ -68,10 +68,10 @@ class App extends Component {
   }
 
   _HandleInput = e => {
-    this._DebouncedStateUpdate(e.target.name, e.target.value)
+    this.__DebouncedHandleInput(e.target.name, e.target.value)
   }
 
-  _DebouncedStateUpdate = debounce(250, (name, value) => {
+  __DebouncedHandleInput = debounce(250, (name, value) => {
     this.setState({ [name]: value, renderCanvas: false })
   })
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -23,7 +23,7 @@ const Config = ({ _HandleInput, width, height, speed, size, primaryColor, second
           type="color"
           id="primaryColor"
           name="primaryColor"
-          value={primaryColor}
+          defaultValue={primaryColor}
           onChange={_HandleInput}
         />
       </p>
@@ -33,7 +33,7 @@ const Config = ({ _HandleInput, width, height, speed, size, primaryColor, second
           type="color"
           id="secondaryColor"
           name="secondaryColor"
-          value={secondaryColor}
+          defaultValue={secondaryColor}
           onChange={_HandleInput}
         />
       </p>


### PR DESCRIPTION
Dragging the color cursor in the OSX color picker re-rendered the canvas many times and caused the canvas animation to completely stop until it could catch up (and my laptop fan to start spinning)

<img width="258" alt="screen shot 2018-01-09 at 10 15 44 pm" src="https://user-images.githubusercontent.com/2709086/34758582-0e9f245e-f58c-11e7-9136-fc9a82cc4208.png">

This change debounce setting the new color value in the state.
Unfortunately, since the value is now debounced, I had to make the inputs uncontrolled.
  
  