### PR TITLE
Fixed: LiveEditor used to push LivePreview component when the length of code is longer than the defined width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,7 +65,7 @@ body {
   background: none !important;
   padding: 0 !important;
   overflow: scroll;
-  width: 555px;
+  max-width: 40vw;
 }
 
 .app-editor__tab {

--- a/src/App.css
+++ b/src/App.css
@@ -57,6 +57,11 @@ body {
   margin-bottom: 4em;
 }
 
+.live-editor {
+  overflow: scroll;
+  width: 555px;
+}
+
 .token.comment {
   color: hsl(0, 0%, 38%) !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -57,11 +57,6 @@ body {
   margin-bottom: 4em;
 }
 
-.live-editor {
-  overflow: scroll;
-  width: 555px;
-}
-
 .token.comment {
   color: hsl(0, 0%, 38%) !important;
 }
@@ -69,6 +64,8 @@ body {
 .prism-code {
   background: none !important;
   padding: 0 !important;
+  overflow: scroll;
+  width: 555px;
 }
 
 .app-editor__tab {

--- a/src/App.js
+++ b/src/App.js
@@ -127,7 +127,7 @@ ${draw}
                 <span className="token comment">{`// 2. Then copy your loader`}</span>
                 <br />
               </pre>
-              <LiveEditor onChange={debounce(500, this._HandleEditor)} />
+              <LiveEditor onChange={debounce(500, this._HandleEditor)} className="live-editor" />
             </div>
 
             <LiveError />

--- a/src/App.js
+++ b/src/App.js
@@ -127,7 +127,7 @@ ${draw}
                 <span className="token comment">{`// 2. Then copy your loader`}</span>
                 <br />
               </pre>
-              <LiveEditor onChange={debounce(500, this._HandleEditor)} className="live-editor" />
+              <LiveEditor onChange={debounce(500, this._HandleEditor)} />
             </div>
 
             <LiveError />


### PR DESCRIPTION
Sometimes when there is a long value as pros in the  LiveEditor it tends to push LivePreview, which leads to a flickering issue, when user try to increase the size of an element from LivePreview.


